### PR TITLE
Replacement of APM usage (Begin/EndGetResponse, etc.) with TAP (GetResponseAsync) and async/await

### DIFF
--- a/src/ClientCommon/HttpCacheRequestHandler.cs
+++ b/src/ClientCommon/HttpCacheRequestHandler.cs
@@ -401,27 +401,27 @@ namespace Microsoft.Synchronization.ClientServices
         /// Issues the BeginGetResponse call for the HttpWebRequest
         /// </summary>
         /// <param name="wrapper">AsyncArgsWrapper object</param>
-        private void GetWebResponse(AsyncArgsWrapper wrapper)
+        private async Task GetWebResponse(AsyncArgsWrapper wrapper)
         {
             // Send the request and wait for the response.
             if (wrapper.CacheRequest.RequestType == CacheRequestType.UploadChanges)
             {
-                wrapper.WebRequest.BeginGetResponse(OnUploadGetResponseCompleted, wrapper);
+                var task = wrapper.WebRequest.GetResponseAsync();
+                await OnUploadGetResponseCompleted(task, wrapper).ConfigureAwait(false);
             }
             else
             {
-                wrapper.WebRequest.BeginGetResponse(OnDownloadGetResponseCompleted, wrapper);
+                var task = wrapper.WebRequest.GetResponseAsync();
+                await OnDownloadGetResponseCompleted(task, wrapper).ConfigureAwait(false);
             }
         }
 
         /// <summary>
         /// Callback for the Upload HttpWebRequest.BeginGetResponse call
         /// </summary>
-        /// <param name="asyncResult">IAsyncResult object</param>
-        void OnUploadGetResponseCompleted(IAsyncResult asyncResult)
+        /// <param name="task">IAsyncResult object</param>
+        async Task OnUploadGetResponseCompleted(Task<WebResponse> task, AsyncArgsWrapper wrapper)
         {
-            AsyncArgsWrapper wrapper = asyncResult.AsyncState as AsyncArgsWrapper;
-
             wrapper.UploadResponse = new ChangeSetResponse();
 
             HttpWebResponse response = null;
@@ -429,7 +429,7 @@ namespace Microsoft.Synchronization.ClientServices
             {
                 try
                 {
-                    response = wrapper.WebRequest.EndGetResponse(asyncResult) as HttpWebResponse;
+                    response = await task.ConfigureAwait(false) as HttpWebResponse;
                 }
                 catch (WebException we)
                 {
@@ -593,10 +593,8 @@ namespace Microsoft.Synchronization.ClientServices
         /// retrieve the list of IOfflineEntity objects and constructs an ChangeSet for that.
         /// </summary>
         /// <param name="asyncResult">IAsyncResult object</param>
-        void OnDownloadGetResponseCompleted(IAsyncResult asyncResult)
+        async Task OnDownloadGetResponseCompleted(Task<WebResponse> task, AsyncArgsWrapper wrapper)
         {
-            AsyncArgsWrapper wrapper = asyncResult.AsyncState as AsyncArgsWrapper;
-
             wrapper.DownloadResponse = new ChangeSet();
 
             HttpWebResponse response = null;
@@ -604,7 +602,7 @@ namespace Microsoft.Synchronization.ClientServices
             {
                 try
                 {
-                    response = wrapper.WebRequest.EndGetResponse(asyncResult) as HttpWebResponse;
+                    response = await task.ConfigureAwait(false) as HttpWebResponse;
                 }
                 catch (WebException we)
                 {

--- a/src/WP7Client/WP7Client.csproj
+++ b/src/WP7Client/WP7Client.csproj
@@ -324,13 +324,26 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.16\lib\wp8\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.16\lib\wp8\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Phone">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.16\lib\wp8\Microsoft.Threading.Tasks.Extensions.Phone.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\lib\Json.Net\Portable\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />
   <ProjectExtensions />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.8\tools\Microsoft.Bcl.Build.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/WP7Client/packages.config
+++ b/src/WP7Client/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl" version="1.0.19" targetFramework="wp80" />
+  <package id="Microsoft.Bcl.Async" version="1.0.16" targetFramework="wp80" />
+  <package id="Microsoft.Bcl.Build" version="1.0.8" targetFramework="wp80" />
+</packages>


### PR DESCRIPTION
As part of a research project at the University of Illinois at Urbana-Champaign, we're developing a refactoring tool that replaces instances of the [APM](http://msdn.microsoft.com/en-us/library/ms228963.aspx) pattern with corresponding [TAP](http://msdn.microsoft.com/en-us/library/hh873175.aspx) method calls and the [async/await](http://msdn.microsoft.com/en-us/library/hh191443.aspx) keywords. I've applied it to this project and found three calls to APM methods.

This pull request replaces those existing calls to APM Begin/End\* methods with functionally equivalent TAP constructs and the async/await keywords.

These two commit contain the actual code-level changes:
- 325f0858350e42352190012882dac6720e1b0966
- 854ed702cf704dbb6abd10b95ba89f7e6db93b4a

I also added a dependency that is needed: [Microsoft.Bcl.Async](https://www.nuget.org/packages/Microsoft.Bcl.Async). This package improves support for async/await-based programming for older frameworks, or frameworks that are missing functionality (for WP, specifically, TAP extension methods for WebRequest).

Are you interested in merging this pull request? If not, please let me know why, and I'll try and improve the pull request with your comments in mind.

Thanks for your time,
David Hartveld
